### PR TITLE
Type stability

### DIFF
--- a/src/RectilinearArrays.jl
+++ b/src/RectilinearArrays.jl
@@ -45,12 +45,12 @@ function RectilinearArray(A::AbstractArray{T}, fixed_indices::NTuple{K,Int}) whe
   new_A = _drop_dims(A, fixed_indices, KernelAbstractions.get_backend(A))
   valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, ndims(A)))
   return RectilinearArray{
-    eltype(A),
+    T,
     ndims(A),
     ndims(new_A),
     typeof(new_A),
     K,
-    length(valid_indices),
+    ndims(A)-length(fixed_indices),
   }(
     new_A, size(A), fixed_indices, valid_indices
   )
@@ -80,12 +80,12 @@ function RectilinearArray(
   new_A = _drop_dims(A, fixed_indices, CPU())
   valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
-    eltype(A),
+    T,
     ndims(A),
     ndims(new_A),
     typeof(new_A),
     length(fixed_indices),
-    length(valid_indices),
+    length(dims)-length(fixed_indices),
   }(
     new_A, size(A), fixed_indices, valid_indices
   )
@@ -98,12 +98,12 @@ function RectilinearArray(
   new_A = _drop_dims(A, fixed_indices, CPU())
   valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
-    eltype(A),
+    T,
     ndims(A),
     ndims(new_A),
     typeof(new_A),
     length(fixed_indices),
-    length(valid_indices),
+    length(dims)-length(fixed_indices),
   }(
     new_A, size(A), fixed_indices, valid_indices
   )
@@ -116,12 +116,12 @@ function RectilinearArray(
   new_A = _drop_dims(A, fixed_indices, backend)
   valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
-    eltype(A),
+    T,
     ndims(A),
     ndims(new_A),
     typeof(new_A),
     length(fixed_indices),
-    length(valid_indices),
+    length(dims)-length(fixed_indices),
   }(
     new_A, size(A), fixed_indices, valid_indices
   )
@@ -134,12 +134,12 @@ function RectilinearArray(
   new_A = _drop_dims(A, fixed_indices, backend)
   valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
-    eltype(A),
+    T,
     ndims(A),
     ndims(new_A),
     typeof(new_A),
     length(fixed_indices),
-    length(valid_indices),
+    length(dims)-length(fixed_indices),
   }(
     new_A, size(A), fixed_indices, valid_indices
   )
@@ -155,7 +155,7 @@ function RectilinearArray(fixed_indices::Tuple{Vararg{Int}}, dims::Dims{N}) wher
     ndims(new_A),
     typeof(new_A),
     length(fixed_indices),
-    length(valid_indices),
+    length(dims)-length(fixed_indices),
   }(
     new_A, size(A), fixed_indices, valid_indices
   )
@@ -171,36 +171,36 @@ function RectilinearArray(fixed_indices::Tuple{Vararg{Int}}, dims::Vararg{Int,N}
     ndims(new_A),
     typeof(new_A),
     length(fixed_indices),
-    length(valid_indices),
+    length(dims)-length(fixed_indices),
   }(
     new_A, size(A), fixed_indices, valid_indices
   )
 end
 
 # Define a zeros function
-function zeros(::Type{T}, fixed_indices::Tuple{Vararg{Int}}, dims::Int...) where {T}
+@inline function zeros(::Type{T}, fixed_indices::Tuple{Vararg{Int}}, dims::Int...) where {T}
   return RectilinearArray(Base.zeros(T, dims...), fixed_indices)
 end
 
-function zeros(::Type{T}, fixed_indices::Tuple{Vararg{Int}}, dims::Dims) where {T}
+@inline function zeros(::Type{T}, fixed_indices::Tuple{Vararg{Int}}, dims::Dims) where {T}
   return RectilinearArray(Base.zeros(T, dims), fixed_indices)
 end
-function zeros(
+@inline function zeros(
   ::Type{T}, backend::Backend, fixed_indices::Tuple{Vararg{Int}}, dims::Int...
 ) where {T}
   return RectilinearArray(KernelAbstractions.zeros(backend, T, dims...), fixed_indices)
 end
 
-function zeros(
+@inline function zeros(
   ::Type{T}, backend::Backend, fixed_indices::Tuple{Vararg{Int}}, dims::Dims
 ) where {T}
   return RectilinearArray(KernelAbstractions.zeros(backend, T, dims), fixed_indices)
 end
-function zeros(fixed_indices::Tuple{Vararg{Int}}, dims::Int...)
+@inline function zeros(fixed_indices::Tuple{Vararg{Int}}, dims::Int...)
   return RectilinearArray(Base.zeros(Float64, dims...), fixed_indices)
 end
 
-function zeros(fixed_indices::Tuple{Vararg{Int}}, dims::Dims)
+@inline function zeros(fixed_indices::Tuple{Vararg{Int}}, dims::Dims)
   return RectilinearArray(Base.zeros(Float64, dims), fixed_indices)
 end
 

--- a/src/RectilinearArrays.jl
+++ b/src/RectilinearArrays.jl
@@ -40,16 +40,16 @@ julia> B = RectilinearArray(A, (1,))
  1  2
 ```
 """
-function RectilinearArray(A::AbstractArray{T}, fixed_indices::Tuple) where {T}
+function RectilinearArray(A::AbstractArray{T}, fixed_indices::NTuple{K,Int}) where {T,K}
   @assert ndims(A) > 0 "RectilinearArray does not support 0-dimensional arrays."
-  new_A = _drop_dims(A, fixed_indices)
-  valid_indices = filter(i -> i ∉ fixed_indices, Tuple(1:ndims(A)))
+  new_A = _drop_dims(A, fixed_indices, KernelAbstractions.get_backend(A))
+  valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, ndims(A)))
   return RectilinearArray{
     eltype(A),
     ndims(A),
     ndims(new_A),
     typeof(new_A),
-    length(fixed_indices),
+    K,
     length(valid_indices),
   }(
     new_A, size(A), fixed_indices, valid_indices
@@ -73,12 +73,12 @@ julia> A = RectilinearArray(Float64, (1,), (2,2))
 ```
 """
 function RectilinearArray(
-  ::Type{T}, fixed_indices::Tuple{Vararg{Int}}, dims::Dims
-) where {T}
+  ::Type{T}, fixed_indices::Tuple{Vararg{Int}}, dims::Dims{N}
+) where {T,N}
   @assert length(dims) > 0 "RectilinearArray does not support 0-dimensional arrays."
   A = Array{T}(undef, dims)
-  new_A = _drop_dims(A, fixed_indices)
-  valid_indices = filter(i -> i ∉ fixed_indices, Tuple(1:ndims(A)))
+  new_A = _drop_dims(A, fixed_indices, CPU())
+  valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
     eltype(A),
     ndims(A),
@@ -91,12 +91,12 @@ function RectilinearArray(
   )
 end
 function RectilinearArray(
-  ::Type{T}, fixed_indices::Tuple{Vararg{Int}}, dims::Int...
-) where {T}
+    ::Type{T}, fixed_indices::Tuple{Vararg{Int}}, dims::Vararg{Int, N}
+) where {T,N}
   @assert length(dims) > 0 "RectilinearArray does not support 0-dimensional arrays."
   A = Array{T}(undef, dims)
-  new_A = _drop_dims(A, fixed_indices)
-  valid_indices = filter(i -> i ∉ fixed_indices, Tuple(1:ndims(A)))
+  new_A = _drop_dims(A, fixed_indices, CPU())
+  valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
     eltype(A),
     ndims(A),
@@ -109,12 +109,12 @@ function RectilinearArray(
   )
 end
 function RectilinearArray(
-  ::Type{T}, backend::Backend, fixed_indices::Tuple{Vararg{Int}}, dims::Dims
-) where {T}
+  ::Type{T}, backend::Backend, fixed_indices::Tuple{Vararg{Int}}, dims::Dims{N}
+) where {T,N}
   @assert length(dims) > 0 "RectilinearArray does not support 0-dimensional arrays."
   A = allocate(backend, T, dims)
-  new_A = _drop_dims(A, fixed_indices)
-  valid_indices = filter(i -> i ∉ fixed_indices, Tuple(1:ndims(A)))
+  new_A = _drop_dims(A, fixed_indices, backend)
+  valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
     eltype(A),
     ndims(A),
@@ -127,12 +127,12 @@ function RectilinearArray(
   )
 end
 function RectilinearArray(
-  ::Type{T}, backend::Backend, fixed_indices::Tuple{Vararg{Int}}, dims::Int...
-) where {T}
+    ::Type{T}, backend::Backend, fixed_indices::Tuple{Vararg{Int}}, dims::Vararg{Int,N}
+) where {T,N}
   @assert length(dims) > 0 "RectilinearArray does not support 0-dimensional arrays."
   A = allocate(backend, T, dims)
-  new_A = _drop_dims(A, fixed_indices)
-  valid_indices = filter(i -> i ∉ fixed_indices, Tuple(1:ndims(A)))
+  new_A = _drop_dims(A, fixed_indices, backend)
+  valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
     eltype(A),
     ndims(A),
@@ -144,11 +144,11 @@ function RectilinearArray(
     new_A, size(A), fixed_indices, valid_indices
   )
 end
-function RectilinearArray(fixed_indices::Tuple{Vararg{Int}}, dims::Dims)
+function RectilinearArray(fixed_indices::Tuple{Vararg{Int}}, dims::Dims{N}) where {N}
   @assert length(dims) > 0 "RectilinearArray does not support 0-dimensional arrays."
   A = Array{Float64}(undef, dims)
-  new_A = _drop_dims(A, fixed_indices)
-  valid_indices = filter(i -> i ∉ fixed_indices, Tuple(1:ndims(A)))
+  new_A = _drop_dims(A, fixed_indices, CPU())
+  valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
     eltype(A),
     ndims(A),
@@ -160,11 +160,11 @@ function RectilinearArray(fixed_indices::Tuple{Vararg{Int}}, dims::Dims)
     new_A, size(A), fixed_indices, valid_indices
   )
 end
-function RectilinearArray(fixed_indices::Tuple{Vararg{Int}}, dims::Int...)
+function RectilinearArray(fixed_indices::Tuple{Vararg{Int}}, dims::Vararg{Int,N}) where {N}
   @assert length(dims) > 0 "RectilinearArray does not support 0-dimensional arrays."
   A = Array{Float64}(undef, dims)
-  new_A = _drop_dims(A, fixed_indices)
-  valid_indices = filter(i -> i ∉ fixed_indices, Tuple(1:ndims(A)))
+  new_A = _drop_dims(A, fixed_indices, CPU())
+  valid_indices = filter(i -> i ∉ fixed_indices, ntuple(i -> i, N))
   return RectilinearArray{
     eltype(A),
     ndims(A),
@@ -304,9 +304,27 @@ function _skip_index(A::AbstractArray, valid_indices::Tuple, inds::Int...)
   return getindex(A, skip...)
 end
 
-function _drop_dims(A::AbstractArray, dims::Tuple)
-  new_dims = ntuple(i -> i ∈ dims ? 1 : Colon(), Val(ndims(A)))
-  return isa(A[new_dims...], Number) ? [A[new_dims...]] : A[new_dims...]
+# function _drop_dims(A::AbstractArray, dims::Tuple)
+#   new_dims = ntuple(i -> i ∈ dims ? 1 : Colon(), Val(ndims(A)))
+#   return isa(A[new_dims...], Number) ? [A[new_dims...]] : A[new_dims...]
+# end
+@kernel function copy_kernel!(R, A, keep_dims)
+    idx = @index(Global, Cartesian)
+    full_idx = ntuple(i -> (i ∈ keep_dims ? idx[findfirst(==(i), keep_dims)] : 1), ndims(A))
+    @inbounds R[idx] = A[full_idx...]
+end
+function _drop_dims(A::AbstractArray, dims::Tuple{Vararg{Int}}, backend::Backend)
+    nd = ndims(A)
+    all_dims = collect(1:nd)
+    keep_dims = ntuple(j -> filter(i -> i ∉ dims, all_dims)[j], nd - length(dims))
+
+    new_shape = ntuple(i -> size(A, keep_dims[i]), nd - length(dims))
+    R = similar(A, eltype(A), new_shape)
+
+    kernel! = copy_kernel!(backend)
+    kernel!(R, A, keep_dims; ndrange=size(R))
+
+    return R
 end
 
 function _largest_eachindex(A...)

--- a/src/grids/1d.jl
+++ b/src/grids/1d.jl
@@ -254,7 +254,7 @@ function _uniform_grid_constructor(
 
   node_velocities = StructArray((x=KernelAbstractions.zeros(backend, T, nodedims),))
 
-  discr_scheme = MetricDiscretizationScheme(;
+  discr_scheme = MontoneExplicitGradientScheme6thOrder(;
     use_cache=true,
     celldims=size(domain_iterators.cell.full),
     backend=backend,

--- a/src/grids/2d.jl
+++ b/src/grids/2d.jl
@@ -110,17 +110,61 @@ function CurvilinearGrid2D(
   empty_metrics=false,
   kwargs...,
 ) where {T}
+
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
+  end
+  
+  coords, centroids, node_velocities, nhalo, nnodes, limits, iterators, is_static, is_orthogonal, scheme_name = _curvilinear_grid_constructor(
+    x,
+    y,
+    discretization_scheme;
+    backend=backend,
+    is_static=is_static,
+    is_orthogonal=is_orthogonal,
+    empty_metrics=empty_metrics,
+  )
+
+  celldims = size(iterators.cell.full)
+
+  cell_center_metrics, edge_metrics = get_metric_soa(celldims, backend, T)
+  # if empty_metrics
+  #   cell_center_metrics, edge_metrics = (nothing, nothing)
+  # else
+  #   cell_center_metrics, edge_metrics = get_metric_soa(celldims, backend, T)
+  # end
+
+  discr_scheme = MetricDiscretizationScheme(;
+    use_cache=true,
+    celldims=celldims,
+    backend=backend,
+    T=T,
+    use_symmetric_conservative_metric_scheme=false,
+  )
+  
   m = CurvilinearGrid2D(
-    _grid_constructor(
-      x,
-      y,
-      :curvilinear,
-      discretization_scheme;
-      backend=backend,
-      is_static=is_static,
-      is_orthogonal=is_orthogonal,
-      empty_metrics=empty_metrics,
-    )...,
+    coords,
+    centroids,
+    node_velocities,
+    edge_metrics,
+    cell_center_metrics,
+    nhalo,
+    nnodes,
+    limits,
+    iterators,
+    discr_scheme,
+    is_static,
+    is_orthogonal,
+    scheme_name,
   )
 
   if init_metrics && !empty_metrics
@@ -175,16 +219,58 @@ function RectilinearGrid2D(
     end
   end
 
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
+  end
+
+  coords, centroids, node_velocities, nhalo, nnodes, limits, iterators, is_static, scheme_name = _rectilinear_grid_constructor(
+        x2d,
+        y2d,
+        discretization_scheme;
+        backend=backend,
+        is_static=is_static,
+        empty_metrics=empty_metrics,
+      )
+
+  celldims = size(iterators.cell.full)
+
+  cell_center_metrics, edge_metrics = get_metric_soa_rectilinear2d(celldims, backend, T)
+  # if empty_metrics
+  #   cell_center_metrics, edge_metrics = (nothing, nothing)
+  # else
+  #   cell_center_metrics, edge_metrics = get_metric_soa_rectilinear2d(celldims, backend, T)
+  # end
+
+  discr_scheme = MetricDiscretizationScheme(;
+    use_cache=true,
+    celldims=celldims,
+    backend=backend,
+    T=T,
+    use_symmetric_conservative_metric_scheme=false,
+  )
+
   m = RectilinearGrid2D(
-    _grid_constructor(
-      x2d,
-      y2d,
-      :rectilinear,
-      discretization_scheme;
-      backend=backend,
-      is_static=is_static,
-      empty_metrics=empty_metrics,
-    )...,
+    coords,
+    centroids,
+    node_velocities,
+    edge_metrics,
+    cell_center_metrics,
+    nhalo,
+    nnodes,
+    limits,
+    iterators,
+    discr_scheme,
+    is_static,
+    scheme_name,
   )
 
   if init_metrics && !empty_metrics
@@ -339,16 +425,58 @@ function UniformGrid2D(
     end
   end
 
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
+  end
+
+  coords, centroids, node_velocities, nhalo, nnodes, limits, iterators, is_static, scheme_name = _uniform_grid_constructor(
+        x2d,
+        y2d,
+        discretization_scheme;
+        backend=backend,
+        is_static=is_static,
+        empty_metrics=empty_metrics,
+      )
+
+  celldims = size(iterators.cell.full)
+
+  cell_center_metrics, edge_metrics = get_metric_soa_uniform2d(celldims, backend, T)
+  # if empty_metrics
+  #   cell_center_metrics, edge_metrics = (nothing, nothing)
+  # else
+  #   cell_center_metrics, edge_metrics = get_metric_soa_uniform2d(celldims, backend, T)
+  # end
+
+  discr_scheme = MetricDiscretizationScheme(;
+    use_cache=true,
+    celldims=celldims,
+    backend=backend,
+    T=T,
+    use_symmetric_conservative_metric_scheme=false,
+  )
+
   m = UniformGrid2D(
-    _grid_constructor(
-      x2d,
-      y2d,
-      :uniform,
-      discretization_scheme;
-      backend=backend,
-      is_static=is_static,
-      empty_metrics=empty_metrics,
-    )...,
+    coords,
+    centroids,
+    node_velocities,
+    edge_metrics,
+    cell_center_metrics,
+    nhalo,
+    nnodes,
+    limits,
+    iterators,
+    discr_scheme,
+    is_static,
+    scheme_name,
   )
 
   if init_metrics && !empty_metrics
@@ -357,10 +485,9 @@ function UniformGrid2D(
   return m
 end
 
-function _grid_constructor(
+function _curvilinear_grid_constructor(
   x::AbstractArray{T,2},
   y::AbstractArray{T,2},
-  tag::Symbol,
   discretization_scheme::Symbol;
   backend=CPU(),
   is_static=false,
@@ -405,25 +532,6 @@ function _grid_constructor(
   celldims = size(domain_iterators.cell.full)
   nodedims = size(domain_iterators.node.full)
 
-  if tag == :rectilinear
-    if empty_metrics
-      cell_center_metrics, edge_metrics = (nothing, nothing)
-    else
-      cell_center_metrics, edge_metrics = get_metric_soa_rectilinear2d(celldims, backend, T)
-    end
-  elseif tag == :uniform
-    if empty_metrics
-      cell_center_metrics, edge_metrics = (nothing, nothing)
-    else
-      cell_center_metrics, edge_metrics = get_metric_soa_uniform2d(celldims, backend, T)
-    end
-  elseif tag == :curvilinear
-    if empty_metrics
-      cell_center_metrics, edge_metrics = (nothing, nothing)
-    else
-      cell_center_metrics, edge_metrics = get_metric_soa(celldims, backend, T)
-    end
-  end
 
   coords = StructArray((
     x=KernelAbstractions.zeros(backend, T, nodedims),
@@ -447,46 +555,180 @@ function _grid_constructor(
     y=KernelAbstractions.zeros(backend, T, nodedims),
   ))
 
-  discr_scheme = MetricDiscretizationScheme(;
-    use_cache=true,
-    celldims=size(domain_iterators.cell.full),
-    backend=backend,
-    T=T,
-    use_symmetric_conservative_metric_scheme=false,
-  )
-
-  if tag == :rectilinear || tag === :uniform
     return (
       coords,
       centroids,
       node_velocities,
-      edge_metrics,
-      cell_center_metrics,
       nhalo,
       nnodes,
       limits,
       domain_iterators,
-      discr_scheme,
-      is_static,
-      scheme_name,
-    )
-  elseif tag === :curvilinear
-    return (
-      coords,
-      centroids,
-      node_velocities,
-      edge_metrics,
-      cell_center_metrics,
-      nhalo,
-      nnodes,
-      limits,
-      domain_iterators,
-      discr_scheme,
       is_static,
       is_orthogonal,
       scheme_name,
     )
+end
+function _rectilinear_grid_constructor(
+  x::AbstractArray{T,2},
+  y::AbstractArray{T,2},
+  discretization_scheme::Symbol;
+  backend=CPU(),
+  is_static=false,
+  is_orthogonal=false,
+  empty_metrics=false,
+  kwargs...,
+) where {T}
+
+  #
+
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
   end
+
+  #
+  @assert size(x) == size(y)
+
+  nnodes = size(x)
+  ni, nj = nnodes
+
+  ncells = nnodes .- 1
+  ni_cells, nj_cells = ncells
+  lo = nhalo + 1
+  limits = (
+    node=(ilo=lo, ihi=ni + nhalo, jlo=lo, jhi=nj + nhalo),
+    cell=(ilo=lo, ihi=ni_cells + nhalo, jlo=lo, jhi=nj_cells + nhalo),
+  )
+
+  nodeCI = CartesianIndices(nnodes .+ 2nhalo)
+  cellCI = CartesianIndices(ncells .+ 2nhalo)
+
+  domain_iterators = get_node_cell_iterators(nodeCI, cellCI, nhalo)
+  celldims = size(domain_iterators.cell.full)
+  nodedims = size(domain_iterators.node.full)
+
+  coords = StructArray((
+    x=KernelAbstractions.zeros(backend, T, nodedims),
+    y=KernelAbstractions.zeros(backend, T, nodedims),
+  ))
+
+  @views begin
+    copy!(coords.x[domain_iterators.node.domain], x)
+    copy!(coords.y[domain_iterators.node.domain], y)
+  end
+
+  centroids = StructArray((
+    x=KernelAbstractions.zeros(backend, T, celldims),
+    y=KernelAbstractions.zeros(backend, T, celldims),
+  ))
+
+  _centroid_coordinates!(centroids, coords, domain_iterators.cell.domain)
+
+  node_velocities = StructArray((
+    x=KernelAbstractions.zeros(backend, T, nodedims),
+    y=KernelAbstractions.zeros(backend, T, nodedims),
+  ))
+
+  return (
+    coords,
+    centroids,
+    node_velocities,
+    nhalo,
+    nnodes,
+    limits,
+    domain_iterators,
+    is_static,
+    scheme_name,
+  )
+end
+function _uniform_grid_constructor(
+  x::AbstractArray{T,2},
+  y::AbstractArray{T,2},
+  discretization_scheme::Symbol;
+  backend=CPU(),
+  is_static=false,
+  is_orthogonal=false,
+  empty_metrics=false,
+  kwargs...,
+) where {T}
+
+  #
+
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
+  end
+
+  #
+  @assert size(x) == size(y)
+
+  nnodes = size(x)
+  ni, nj = nnodes
+
+  ncells = nnodes .- 1
+  ni_cells, nj_cells = ncells
+  lo = nhalo + 1
+  limits = (
+    node=(ilo=lo, ihi=ni + nhalo, jlo=lo, jhi=nj + nhalo),
+    cell=(ilo=lo, ihi=ni_cells + nhalo, jlo=lo, jhi=nj_cells + nhalo),
+  )
+
+  nodeCI = CartesianIndices(nnodes .+ 2nhalo)
+  cellCI = CartesianIndices(ncells .+ 2nhalo)
+
+  domain_iterators = get_node_cell_iterators(nodeCI, cellCI, nhalo)
+  celldims = size(domain_iterators.cell.full)
+  nodedims = size(domain_iterators.node.full)
+
+  coords = StructArray((
+    x=KernelAbstractions.zeros(backend, T, nodedims),
+    y=KernelAbstractions.zeros(backend, T, nodedims),
+  ))
+
+  @views begin
+    copy!(coords.x[domain_iterators.node.domain], x)
+    copy!(coords.y[domain_iterators.node.domain], y)
+  end
+
+  centroids = StructArray((
+    x=KernelAbstractions.zeros(backend, T, celldims),
+    y=KernelAbstractions.zeros(backend, T, celldims),
+  ))
+
+  _centroid_coordinates!(centroids, coords, domain_iterators.cell.domain)
+
+  node_velocities = StructArray((
+    x=KernelAbstractions.zeros(backend, T, nodedims),
+    y=KernelAbstractions.zeros(backend, T, nodedims),
+  ))
+
+  return (
+    coords,
+    centroids,
+    node_velocities,
+    nhalo,
+    nnodes,
+    limits,
+    domain_iterators,
+    is_static,
+    scheme_name,
+  )
 end
 
 function AxisymmetricGrid2D(

--- a/src/grids/3d.jl
+++ b/src/grids/3d.jl
@@ -62,7 +62,24 @@ function CurvilinearGrid3D(
   empty_metrics=false,
   kwargs...,
 ) where {T}
-  m = _curvilinear_grid_constructor(
+
+  use_symmetric_conservative_metric_scheme = false
+
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+    use_symmetric_conservative_metric_scheme = true
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
+  end
+
+  coords, centroids, node_velocities, nhalo, nnodes, limits, iterators, is_static, is_orthogonal, scheme_name = _curvilinear_grid_constructor(
         x,
         y,
         z,
@@ -72,6 +89,40 @@ function CurvilinearGrid3D(
         is_orthogonal=is_orthogonal,
         empty_metrics=empty_metrics,
       )
+
+  celldims = size(iterators.cell.full)
+
+  discr_scheme = MetricDiscretizationScheme(;
+    use_cache=true,
+    celldims=celldims,
+    backend=backend,
+    T=T,
+    use_symmetric_conservative_metric_scheme=use_symmetric_conservative_metric_scheme,
+  )
+
+  # if init_metrics
+  cell_center_metrics, edge_metrics = get_metric_soa(celldims, backend, T)
+  # if empty_metrics
+  #   cell_center_metrics, edge_metrics = (nothing, nothing)
+  # else
+  #   cell_center_metrics, edge_metrics = get_metric_soa(celldims, backend, T)
+  # end
+
+  m = CurvilinearGrid3D(
+    coords,
+    centroids,
+    node_velocities,
+    edge_metrics,
+    cell_center_metrics,
+    nhalo,
+    nnodes,
+    limits,
+    iterators,
+    discr_scheme,
+    is_static,
+    is_orthogonal,
+    scheme_name,
+  )
 
   if init_metrics && !empty_metrics
     update!(m; force=true)
@@ -142,7 +193,23 @@ function RectilinearGrid3D(
     end
   end
 
-  m = _rectilinear_grid_constructor(
+  use_symmetric_conservative_metric_scheme = false
+
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+    use_symmetric_conservative_metric_scheme = true
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
+  end
+
+  coords, centroids, node_velocities, nhalo, nnodes, limits, iterators, is_static, scheme_name = _rectilinear_grid_constructor(
         x3d,
         y3d,
         z3d,
@@ -152,6 +219,39 @@ function RectilinearGrid3D(
         empty_metrics=empty_metrics,
         kwargs...,
       )
+
+  celldims = size(iterators.cell.full)
+
+  discr_scheme = MetricDiscretizationScheme(;
+    use_cache=true,
+    celldims=celldims,
+    backend=backend,
+    T=T,
+    use_symmetric_conservative_metric_scheme=use_symmetric_conservative_metric_scheme,
+  )
+
+  # if init_metrics
+  cell_center_metrics, edge_metrics = get_metric_soa_rectilinear3d(celldims, backend, T)
+  # if empty_metrics
+  #   cell_center_metrics, edge_metrics = (nothing, nothing)
+  # else
+  #   cell_center_metrics, edge_metrics = get_metric_soa_rectilinear3d(celldims, backend, T)
+  # end
+
+  m = RectilinearGrid3D(
+    coords,
+    centroids,
+    node_velocities,
+    edge_metrics,
+    cell_center_metrics,
+    nhalo,
+    nnodes,
+    limits,
+    iterators,
+    discr_scheme,
+    is_static,
+    scheme_name,
+  )
 
   if init_metrics && !empty_metrics
     update!(m; force=true)
@@ -250,8 +350,23 @@ function RectilinearGrid3D(
     end
   end
 
-  # Here we use the 'uniform' tag because all of the metric matrices are uniform
-  m = _rectilinear_grid_constructor(
+  use_symmetric_conservative_metric_scheme = false
+
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+    use_symmetric_conservative_metric_scheme = true
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
+  end
+
+  coords, centroids, node_velocities, nhalo, nnodes, limits, iterators, is_static, scheme_name = _uniform_grid_constructor(
         x3d,
         y3d,
         z3d,
@@ -261,6 +376,43 @@ function RectilinearGrid3D(
         empty_metrics=empty_metrics,
         kwargs...,
       )
+
+  celldims = size(iterators.cell.full)
+
+  discr_scheme = MetricDiscretizationScheme(;
+    use_cache=true,
+    celldims=celldims,
+    backend=backend,
+    T=T,
+    use_symmetric_conservative_metric_scheme=use_symmetric_conservative_metric_scheme,
+  )
+
+  # if init_metrics
+  cell_center_metrics, edge_metrics = get_metric_soa_uniform3d(celldims, backend, T)
+  # if empty_metrics
+  #   cell_center_metrics, edge_metrics = (nothing, nothing)
+  # else
+  #   cell_center_metrics, edge_metrics = get_metric_soa_uniform3d(celldims, backend, T)
+  # end
+  # else
+  #   cell_center_metrics = nothing
+  #   edge_metrics = nothing
+  # end
+
+  m = RectilinearGrid3D(
+    coords,
+    centroids,
+    node_velocities,
+    edge_metrics,
+    cell_center_metrics,
+    nhalo,
+    nnodes,
+    limits,
+    iterators,
+    discr_scheme,
+    is_static,
+    scheme_name,
+  )
 
   if init_metrics && !empty_metrics
     update!(m; force=true)
@@ -333,7 +485,23 @@ function UniformGrid3D(
     end
   end
 
-  m = _uniform_grid_constructor(
+  use_symmetric_conservative_metric_scheme = false
+
+  scheme_name = Symbol(uppercase("$discretization_scheme"))
+  if scheme_name === :MEG6 ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+  elseif scheme_name === :MEG6_SYMMETRIC ||
+    discretization_scheme == :MontoneExplicitGradientScheme6thOrder
+    MetricDiscretizationScheme = MontoneExplicitGradientScheme6thOrder
+    nhalo = 5
+    use_symmetric_conservative_metric_scheme = true
+  else
+    error("Only MontoneExplicitGradientScheme6thOrder or MEG6 is supported for now")
+  end
+
+  coords, centroids, node_velocities, nhalo, nnodes, limits, iterators, is_static, scheme_name = _uniform_grid_constructor(
         x3d,
         y3d,
         z3d,
@@ -343,6 +511,43 @@ function UniformGrid3D(
         empty_metrics=empty_metrics,
         kwargs...,
       )
+
+  celldims = size(iterators.cell.full)
+
+  discr_scheme = MetricDiscretizationScheme(;
+    use_cache=true,
+    celldims=celldims,
+    backend=backend,
+    T=T,
+    use_symmetric_conservative_metric_scheme=use_symmetric_conservative_metric_scheme,
+  )
+
+  # if init_metrics
+  cell_center_metrics, edge_metrics = get_metric_soa_uniform3d(celldims, backend, T)
+  # if empty_metrics
+  #   cell_center_metrics, edge_metrics = (nothing, nothing)
+  # else
+  #   cell_center_metrics, edge_metrics = get_metric_soa_uniform3d(celldims, backend, T)
+  # end
+  # else
+  #   cell_center_metrics = nothing
+  #   edge_metrics = nothing
+  # end
+
+  m = UniformGrid3D(
+    coords,
+    centroids,
+    node_velocities,
+    edge_metrics,
+    cell_center_metrics,
+    nhalo,
+    nnodes,
+    limits,
+    iterators,
+    discr_scheme,
+    is_static,
+    scheme_name,
+  )
 
   if init_metrics && !empty_metrics
     update!(m; force=true)
@@ -408,23 +613,8 @@ function _curvilinear_grid_constructor(
 
   domain_iterators = get_node_cell_iterators(nodeCI, cellCI, nhalo)
 
-  discr_scheme = MetricDiscretizationScheme(;
-    use_cache=true,
-    celldims=size(domain_iterators.cell.full),
-    backend=backend,
-    T=T,
-    use_symmetric_conservative_metric_scheme=use_symmetric_conservative_metric_scheme,
-  )
-
   celldims = size(domain_iterators.cell.full)
   nodedims = size(domain_iterators.node.full)
-
-  # if init_metrics
-  if empty_metrics
-    cell_center_metrics, edge_metrics = (nothing, nothing)
-  else
-    cell_center_metrics, edge_metrics = get_metric_soa(celldims, backend, T)
-  end
 
   coords = StructArray((
     x=KernelAbstractions.zeros(backend, T, nodedims),
@@ -451,17 +641,14 @@ function _curvilinear_grid_constructor(
     z=KernelAbstractions.zeros(backend, T, nodedims),
   ))
 
-  return CurvilinearGrid3D{typeof(coords), typeof(centroids), typeof(node_velocities), typeof(edge_metrics), typeof(cell_center_metrics), typeof(limits), typeof(domain_iterators), typeof(discr_scheme)}(
+  return (
     coords,
     centroids,
     node_velocities,
-    edge_metrics,
-    cell_center_metrics,
     nhalo,
     nnodes,
     limits,
     domain_iterators,
-    discr_scheme,
     is_static,
     is_orthogonal,
     scheme_name,
@@ -524,23 +711,8 @@ function _rectilinear_grid_constructor(
 
   domain_iterators = get_node_cell_iterators(nodeCI, cellCI, nhalo)
 
-  discr_scheme = MetricDiscretizationScheme(;
-    use_cache=true,
-    celldims=size(domain_iterators.cell.full),
-    backend=backend,
-    T=T,
-    use_symmetric_conservative_metric_scheme=use_symmetric_conservative_metric_scheme,
-  )
-
   celldims = size(domain_iterators.cell.full)
   nodedims = size(domain_iterators.node.full)
-
-  # if init_metrics
-  if empty_metrics
-    cell_center_metrics, edge_metrics = (nothing, nothing)
-  else
-    cell_center_metrics, edge_metrics = get_metric_soa_rectilinear3d(celldims, backend, T)
-  end
 
   coords = StructArray((
     x=KernelAbstractions.zeros(backend, T, nodedims),
@@ -567,17 +739,14 @@ function _rectilinear_grid_constructor(
     z=KernelAbstractions.zeros(backend, T, nodedims),
   ))
 
-  return RectilinearGrid3D{typeof(coords), typeof(centroids), typeof(node_velocities), typeof(edge_metrics), typeof(cell_center_metrics), typeof(limits), typeof(domain_iterators), typeof(discr_scheme)}(
+  return (
     coords,
     centroids,
     node_velocities,
-    edge_metrics,
-    cell_center_metrics,
     nhalo,
     nnodes,
     limits,
     domain_iterators,
-    discr_scheme,
     is_static,
     scheme_name,
   )
@@ -639,28 +808,8 @@ function _uniform_grid_constructor(
 
   domain_iterators = get_node_cell_iterators(nodeCI, cellCI, nhalo)
 
-  discr_scheme = MetricDiscretizationScheme(;
-    use_cache=true,
-    celldims=size(domain_iterators.cell.full),
-    backend=backend,
-    T=T,
-    use_symmetric_conservative_metric_scheme=use_symmetric_conservative_metric_scheme,
-  )
-
   celldims = size(domain_iterators.cell.full)
   nodedims = size(domain_iterators.node.full)
-
-  # if init_metrics
-  cell_center_metrics, edge_metrics = get_metric_soa_uniform3d(celldims, backend, T)
-  # if empty_metrics
-  #   cell_center_metrics, edge_metrics = (nothing, nothing)
-  # else
-  #   cell_center_metrics, edge_metrics = get_metric_soa_uniform3d(celldims, backend, T)
-  # end
-  # else
-  #   cell_center_metrics = nothing
-  #   edge_metrics = nothing
-  # end
 
   coords = StructArray((
     x=KernelAbstractions.zeros(backend, T, nodedims),
@@ -687,17 +836,14 @@ function _uniform_grid_constructor(
     z=KernelAbstractions.zeros(backend, T, nodedims),
   ))
 
-  return UniformGrid3D{typeof(coords), typeof(centroids), typeof(node_velocities), typeof(edge_metrics), typeof(cell_center_metrics), typeof(limits), typeof(domain_iterators), typeof(discr_scheme)}(
+  return (
     coords,
     centroids,
     node_velocities,
-    edge_metrics,
-    cell_center_metrics,
     nhalo,
     nnodes,
     limits,
     domain_iterators,
-    discr_scheme,
     is_static,
     scheme_name,
   )

--- a/src/grids/GridTypes.jl
+++ b/src/grids/GridTypes.jl
@@ -128,7 +128,7 @@ end
   )
 end
 
-@inline function coords(mesh::CurvilinearGrid3D)
+@inline function coords(mesh::AbstractCurvilinearGrid3D)
   return @views (
     mesh.node_coordinates.x[mesh.iterators.node.domain],
     mesh.node_coordinates.y[mesh.iterators.node.domain],
@@ -153,7 +153,7 @@ end
   )
 end
 
-@inline function centroids(mesh::CurvilinearGrid3D)
+@inline function centroids(mesh::AbstractCurvilinearGrid3D)
   return @views (
     mesh.centroid_coordinates.x[mesh.iterators.cell.domain],
     mesh.centroid_coordinates.y[mesh.iterators.cell.domain],

--- a/src/grids/metric_soa.jl
+++ b/src/grids/metric_soa.jl
@@ -782,7 +782,7 @@ function get_metric_soa(celldims::NTuple{1,Int}, backend, T)
   return cell_center_metrics, edge_metrics
 end
 
-function get_metric_soa_uniform1d(celldims::NTuple{1,Int}, backend, T)
+function get_metric_soa_uniform1d(celldims::NTuple{1,Int}, backend::Backend, ::Type{T}) where {T}
   cell_center_metrics = (
     J=RectilinearArrays.zeros(T, backend, (1,), celldims),
     ξ=StructArray((


### PR DESCRIPTION
Update the grid constructor functions to be type stable. Note: due to the inner workings of the metric scheme function, the variable "discr_scheme" can be two different things. This doesn't cause type instability in the grid constructor functions, however, because the return type will be a union of two types, one with the first "discr_scheme" and the second with the other "discr_scheme".